### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build and Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/0SkillAllLuck/homebridge-argo/security/code-scanning/1](https://github.com/0SkillAllLuck/homebridge-argo/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only performs read operations (e.g., checking out the repository and installing dependencies), we will set `contents: read` as the permission. This ensures that the workflow has the least privilege necessary to complete its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
